### PR TITLE
Annulled configuration tick rate dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ coverage_report/
 #private google cloud iot configs
 client_cfg.h
 .vscode
+.sh
 #auto generated headers from cmake
 third_party/libjwt/config.h

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,6 @@ coverage_report/
 
 #private google cloud iot configs
 client_cfg.h
-
+.vscode
 #auto generated headers from cmake
 third_party/libjwt/config.h

--- a/examples/apps/demo_101/demo_101.cpp
+++ b/examples/apps/demo_101/demo_101.cpp
@@ -149,7 +149,7 @@ void demo101Task(void *p)
     printf("Enable thread\n");
     OT_API_CALL(otThreadSetEnabled(otrGetInstance(), true));
     // wait a while for thread to connect
-    vTaskDelay(2000);
+    vTaskDelay(pdMS_TO_TICKS(2000));
 
     // dns64 www.google.com
     printf("Start curl www.google.com\n");
@@ -164,7 +164,7 @@ void demo101Task(void *p)
         httpc_state_t *connection;
         httpc_get_file(&serverAddr, 80, "/", &httpSettings, HttpRecvCallback, NULL, &connection);
         WaitForSignal(HTTP_BIT);
-        if (xTaskNotifyWait(BUTTON_BIT, BUTTON_BIT, &notifyValue, 10000) == pdTRUE)
+        if (xTaskNotifyWait(BUTTON_BIT, BUTTON_BIT, &notifyValue, pdMS_TO_TICKS(10000)) == pdTRUE)
         {
             break;
         }

--- a/examples/apps/test/mqtt.cpp
+++ b/examples/apps/test/mqtt.cpp
@@ -339,7 +339,7 @@ void mqttTask(void *p)
         snprintf(msg, sizeof(msg), "{\"temperature\": %d}", temperature - 5);
         client.Publish(pubTopic, msg, strlen(msg));
         printf("Publish message: %s\r\n", msg);
-        vTaskDelay(2000);
+        vTaskDelay(pdMS_TO_TICKS(2000));
     }
 
 exit:


### PR DESCRIPTION
Noticed this in the Google I/O 2019 talk's code snippet.
vTaskDelay actually accepts the number of ticks to delay for and not time in ms.
The time is dependent on the tick rate.