### PR TITLE
[netif] allow compilation when lwIP IPv4 is disabled

### DIFF
--- a/include/net/utils/nat64_utils.h
+++ b/include/net/utils/nat64_utils.h
@@ -38,7 +38,9 @@ extern "C" {
 
 void setNat64Prefix(const ip6_addr_t *aNat64Prefix);
 
+#if LWIP_IPV4
 ip6_addr_t getNat64Address(const ip4_addr_t *aIpv4Address);
+#endif
 
 int dnsNat64Address(const char *aHostName, ip6_addr_t *aAddrOut);
 


### PR DESCRIPTION
Some minor changes to allow compilation if you disable IPv4 support in lwIP.  I haven't done that in the committed sources, but if someone does, then they shouldn't hit roadblocks.